### PR TITLE
feat(frontend): add upload mode selection and undo button

### DIFF
--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 export default function Upload() {
   const [file, setFile] = useState(null);
   const [status, setStatus] = useState("");
+  const [mode, setMode] = useState("append");
+  const [lastBatchId, setLastBatchId] = useState(null);
 
   const handleUpload = async () => {
     if (!file) return;
@@ -12,16 +14,33 @@ export default function Upload() {
 
     try {
       setStatus("Subiendo...");
-      const res = await fetch("http://localhost:8000/upload", {
+      const res = await fetch(`http://localhost:8000/upload?mode=${mode}`, {
         method: "POST",
-        body: formData,   // 👈 no pongas headers, el navegador los añade
+        body: formData, // 👈 no pongas headers, el navegador los añade
       });
 
       if (!res.ok) throw new Error("Error en la subida");
       const data = await res.json();
       setStatus("✅ " + data.message);
+      setLastBatchId(data.batch_id);
     } catch (err) {
       setStatus("❌ Error subiendo archivo");
+      console.error(err);
+    }
+  };
+
+  const handleUndo = async () => {
+    if (!lastBatchId) return;
+    try {
+      setStatus("Deshaciendo último upload...");
+      const res = await fetch(`http://localhost:8000/upload/${lastBatchId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Error deshaciendo upload");
+      setStatus("✅ Último upload revertido");
+      setLastBatchId(null);
+    } catch (err) {
+      setStatus("❌ Error deshaciendo upload");
       console.error(err);
     }
   };
@@ -32,17 +51,38 @@ export default function Upload() {
 
       <input
         type="file"
-        accept=".xlsx"
+        accept=".xlsx,.xls,.csv"
         onChange={(e) => setFile(e.target.files[0])}
         className="mb-4"
       />
 
-      <button
-        onClick={handleUpload}
-        className="px-4 py-2 bg-indigo-600 text-white rounded"
-      >
-        Subir
-      </button>
+      <div className="mb-4">
+        <label className="mr-2 font-semibold">Modo:</label>
+        <select
+          value={mode}
+          onChange={(e) => setMode(e.target.value)}
+          className="border rounded px-2 py-1"
+        >
+          <option value="append">Append</option>
+          <option value="replace">Replace</option>
+        </select>
+      </div>
+
+      <div className="space-x-2">
+        <button
+          onClick={handleUpload}
+          className="px-4 py-2 bg-indigo-600 text-white rounded"
+        >
+          Subir
+        </button>
+        <button
+          onClick={handleUndo}
+          disabled={!lastBatchId}
+          className="px-4 py-2 bg-gray-400 text-white rounded disabled:opacity-50"
+        >
+          Deshacer último upload
+        </button>
+      </div>
 
       {status && <p className="mt-4">{status}</p>}
     </div>


### PR DESCRIPTION
## Summary
- allow selecting append or replace when uploading files
- support undoing the most recent upload once backend endpoints exist

## Testing
- `npx prettier src/pages/Upload.jsx --write`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b293cfa52483219bafd5814ce2d375