### PR TITLE
feat: add upload history endpoints

### DIFF
--- a/backend/schemas/upload.py
+++ b/backend/schemas/upload.py
@@ -1,10 +1,27 @@
+"""Schemas for upload endpoints."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel
-from typing import List, Dict, Optional
+
 
 class UploadResponse(BaseModel):
+    """Response returned after a successful upload."""
+
     status: str
     message: str
     rows: Optional[int] = None
     columns: Optional[List[str]] = None
-    sample: Optional[List[Dict[str, Any]]] = None  # <- tipado explícito
-    batch_id: Optional[str] = None   # ← nuevo
+    sample: Optional[List[Dict[str, Any]]] = None
+    batch_id: Optional[str] = None
+
+
+class UploadHistoryItem(BaseModel):
+    """Single upload history record."""
+
+    batch_id: str
+    filename: str
+    mode: str
+    rows: int
+    created_at: datetime


### PR DESCRIPTION
## Summary
- add `GET /upload/history` to list upload batches
- add `DELETE /upload/{batch_id}` to remove uploaded sales
- expose `UploadHistoryItem` schema for history entries

## Testing
- `python -m black backend/api/upload.py backend/schemas/upload.py`
- `ruff check backend/api/upload.py backend/schemas/upload.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b293c6c7e88321a579cf4177d84997