### PR TITLE
feat: add batch id to sales ingest

### DIFF
--- a/backend/services/ingest.py
+++ b/backend/services/ingest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 from db.models import Sale
 
+
 # ---------- helpers ----------
 def _coerce_money(series: pd.Series) -> pd.Series:
     """Convierte '1.234,56 €' | '1,234.56' | '1234' a float."""
@@ -12,10 +13,13 @@ def _coerce_money(series: pd.Series) -> pd.Series:
     s = series.astype(str)
     s = s.str.replace(r"[€$£]", "", regex=True).str.replace(r"\s+", "", regex=True)
     comma_decimal = s.str.contains(r",\d{1,2}$", na=False)
-    s = s.where(~comma_decimal,
-                s.str.replace(".", "", regex=False).str.replace(",", ".", regex=False))
+    s = s.where(
+        ~comma_decimal,
+        s.str.replace(".", "", regex=False).str.replace(",", ".", regex=False),
+    )
     s = s.where(comma_decimal, s.str.replace(",", "", regex=False))
     return pd.to_numeric(s, errors="coerce")
+
 
 def _coerce_percent(series: pd.Series) -> pd.Series:
     """Convierte '12,5%' | '12.5%' | 0.125 | 12.5 a fracción 0..1."""
@@ -28,17 +32,21 @@ def _coerce_percent(series: pd.Series) -> pd.Series:
     s = s.str.replace(r"\s+", "", regex=True)
     # normaliza coma decimal
     comma_decimal = s.str.contains(r",\d{1,2}$", na=False)
-    s = s.where(~comma_decimal,
-                s.str.replace(".", "", regex=False).str.replace(",", ".", regex=False))
+    s = s.where(
+        ~comma_decimal,
+        s.str.replace(".", "", regex=False).str.replace(",", ".", regex=False),
+    )
     s = s.where(comma_decimal, s.str.replace(",", "", regex=False))
     s = pd.to_numeric(s, errors="coerce")
     return s.where(s <= 1, s / 100.0)
+
 
 def _join_cols(df: pd.DataFrame, cols: list[str], new_col: str):
     """Concatena columnas no vacías con ' | '."""
     existing = [c for c in cols if c in df.columns]
     if not existing:
         return
+
     def _row_join(row):
         vals = []
         for c in existing:
@@ -46,7 +54,9 @@ def _join_cols(df: pd.DataFrame, cols: list[str], new_col: str):
             if pd.notna(v) and str(v).strip():
                 vals.append(str(v).strip())
         return " | ".join(vals) if vals else None
+
     df[new_col] = df.apply(_row_join, axis=1)
+
 
 # ---------- normalización principal ----------
 def _normalize_df(df: pd.DataFrame) -> pd.DataFrame:
@@ -74,8 +84,14 @@ def _normalize_df(df: pd.DataFrame) -> pd.DataFrame:
     #    usando los nombres en minúsculas tal cual vienen del Excel
     _join_cols(df, ["c.mercado", "c.sociedad", "c.pais", "c.area"], "market")
     _join_cols(df, ["c.uen", "c.uen2", "c.segmento"], "segment")
-    _join_cols(df, ["c.representante", "c.cliente", "c.conb2b", "c.tramoactual"], "customer")
-    _join_cols(df, ["a.familia", "a.subfamilia", "a.articulotipo1", "a.descripcion", "a.tipo"], "product")
+    _join_cols(
+        df, ["c.representante", "c.cliente", "c.conb2b", "c.tramoactual"], "customer"
+    )
+    _join_cols(
+        df,
+        ["a.familia", "a.subfamilia", "a.articulotipo1", "a.descripcion", "a.tipo"],
+        "product",
+    )
 
     # 4) tipos: fecha y métricas
     if "date" in df.columns:
@@ -100,20 +116,31 @@ def _normalize_df(df: pd.DataFrame) -> pd.DataFrame:
         df["discount_pct"] = _coerce_percent(df["discount_raw"]).fillna(0.0)
 
     if "quantity" in df.columns:
-        df["quantity"] = pd.to_numeric(df["quantity"], errors="coerce").fillna(0).astype(int)
+        df["quantity"] = (
+            pd.to_numeric(df["quantity"], errors="coerce").fillna(0).astype(int)
+        )
 
     # 5) agrupación/deduplicado dentro del archivo
-    group_keys = [c for c in ["date", "market", "segment", "customer", "product"] if c in df.columns]
+    group_keys = [
+        c
+        for c in ["date", "market", "segment", "customer", "product"]
+        if c in df.columns
+    ]
     agg = {}
-    if "amount" in df.columns: agg["amount"] = "sum"
-    if "margin_eur" in df.columns: agg["margin_eur"] = "sum"
-    if "quantity" in df.columns: agg["quantity"] = "sum"
+    if "amount" in df.columns:
+        agg["amount"] = "sum"
+    if "margin_eur" in df.columns:
+        agg["margin_eur"] = "sum"
+    if "quantity" in df.columns:
+        agg["quantity"] = "sum"
 
     # media ponderada de descuento por importe
     if "discount_pct" in df.columns and "amount" in df.columns:
         df["_disc_weight"] = df["discount_pct"] * df["amount"]
         agg["_disc_weight"] = "sum"
-        agg["_amount_for_disc"] = ("amount", "sum") if isinstance(agg["amount"], tuple) else "sum"
+        agg["_amount_for_disc"] = (
+            ("amount", "sum") if isinstance(agg["amount"], tuple) else "sum"
+        )
         # truco: guardamos amount ya arriba; repetimos para denominador
         df["_amount_for_disc"] = df["amount"]
 
@@ -126,30 +153,37 @@ def _normalize_df(df: pd.DataFrame) -> pd.DataFrame:
 
     return df
 
+
 # ---------- inserción ----------
-def _bulk_insert_sales(df: pd.DataFrame, db: Session):
+def _bulk_insert_sales(df: pd.DataFrame, db: Session, batch_id: str):
     """Inserta sin commit; el commit/rollback lo gestiona el endpoint (transacción)."""
-    records = []
+    records: list[Sale] = []
     for _, r in df.iterrows():
-        records.append(Sale(
-            date=r.get("date"),
-            customer=r.get("customer"),  # compuesto
-            product=r.get("product"),    # compuesto
-            amount=float(r.get("amount", 0) or 0),
-            margin=float(r.get("margin_eur", 0) or 0),  # margen en €
-            quantity=int(r.get("quantity", 0) or 0),
-        ))
+        records.append(
+            Sale(
+                date=r.get("date"),
+                customer=r.get("customer"),  # compuesto
+                product=r.get("product"),  # compuesto
+                amount=float(r.get("amount", 0) or 0),
+                margin=float(r.get("margin_eur", 0) or 0),  # margen en €
+                quantity=int(r.get("quantity", 0) or 0),
+                batch_id=batch_id,
+            )
+        )
     if records:
         db.add_all(records)
+
 
 # ---------- API para el endpoint ----------
 def parse_sales_from_excel(path: Path) -> pd.DataFrame:
     df = pd.read_excel(path)
     return _normalize_df(df)
 
+
 def parse_sales_from_csv(path: Path) -> pd.DataFrame:
     df = pd.read_csv(path)
     return _normalize_df(df)
 
-def bulk_insert_sales(df: pd.DataFrame, db: Session):
-    _bulk_insert_sales(df, db)  # sin commit
+
+def bulk_insert_sales(df: pd.DataFrame, db: Session, batch_id: str):
+    _bulk_insert_sales(df, db, batch_id=batch_id)  # sin commit


### PR DESCRIPTION
## Summary
- track `batch_id` when inserting sales

## Testing
- `black backend/services/ingest.py`
- `ruff check backend/services/ingest.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b293b8abdc8321b29f3d1395e51c1d