### PR TITLE
feat: track batches for sales uploads

### DIFF
--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1,5 +1,15 @@
-from sqlalchemy import Column, Integer, String, Date, Float
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Date, Float, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
 from db.session import Base
+
+
+class Batch(Base):
+    __tablename__ = "batches"
+
+    id = Column(Integer, primary_key=True, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    sales = relationship("Sale", back_populates="batch", cascade="all, delete-orphan")
 
 class Sale(Base):
     __tablename__ = "sales"
@@ -11,3 +21,5 @@ class Sale(Base):
     amount = Column(Float)                   # Venta 💰
     margin = Column(Float)                   # Margen %
     quantity = Column(Integer)               # Cantidad
+    batch_id = Column(Integer, ForeignKey("batches.id"), index=True)
+    batch = relationship("Batch", back_populates="sales")

--- a/backend/migrations/versions/ee5df5cfa1d2_add_batches.py
+++ b/backend/migrations/versions/ee5df5cfa1d2_add_batches.py
@@ -1,0 +1,41 @@
+"""add batches table and batch_id to sales
+
+Revision ID: ee5df5cfa1d2
+Revises: cdb7a72fc2d2
+Create Date: 2025-10-20 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ee5df5cfa1d2'
+down_revision: Union[str, Sequence[str], None] = 'cdb7a72fc2d2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'batches',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_batches_id'), 'batches', ['id'], unique=False)
+    op.add_column('sales', sa.Column('batch_id', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_sales_batch_id'), 'sales', ['batch_id'], unique=False)
+    op.create_foreign_key(None, 'sales', 'batches', ['batch_id'], ['id'], ondelete='CASCADE')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(None, 'sales', type_='foreignkey')
+    op.drop_index(op.f('ix_sales_batch_id'), table_name='sales')
+    op.drop_column('sales', 'batch_id')
+    op.drop_index(op.f('ix_batches_id'), table_name='batches')
+    op.drop_table('batches')


### PR DESCRIPTION
## Summary
- add Batch model and link Sale rows via batch_id
- create and use batch when uploading sales; allow undo of last batch
- support batch tracking in ingestion service with migration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2aa5fe684832199de9b62d56c542c