### PR TITLE
fix(frontend): resolve Upload import path

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,8 +1,16 @@
 // frontend/src/pages/Dashboard.jsx
 import { useEffect, useState } from "react";
 import client from "../api/client";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from "recharts";
-import Upload from "../components/Upload"; // ← ruta corregida
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import Upload from "../components/Upload.jsx";
 
 export default function Dashboard() {
   const [kpis, setKpis] = useState(null);


### PR DESCRIPTION
## Summary
- ensure Upload component is imported with explicit `.jsx` extension in Dashboard page to fix Vite import resolution

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2a23e30988321a3094abd04f81a38