### PR TITLE
fix: support legacy Excel uploads

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ python-multipart
 alembic
 python-dotenv
 openpyxl
+xlrd
 pydantic-settings
 psycopg[binary]
 jinja2

--- a/backend/services/ingest.py
+++ b/backend/services/ingest.py
@@ -179,7 +179,17 @@ def _bulk_insert_sales(df: pd.DataFrame, db: Session, batch_id: str):
 
 # ---------- API para el endpoint ----------
 def parse_sales_from_excel(path: Path) -> pd.DataFrame:
-    df = pd.read_excel(path)
+    """Parse an Excel file (``.xlsx``/``.xls``) into the normalized format.
+
+    Pandas relies on different engines depending on the extension. Older
+    ``.xls`` files require the ``xlrd`` package while modern ``.xlsx`` files use
+    ``openpyxl``. Selecting the engine explicitly avoids pandas trying the wrong
+    one and provides a clearer error message if the dependency is missing.
+    """
+
+    ext = path.suffix.lower()
+    engine = "xlrd" if ext == ".xls" else "openpyxl"
+    df = pd.read_excel(path, engine=engine)
     return _normalize_df(df)
 
 

--- a/backend/tests/test_ingest.py
+++ b/backend/tests/test_ingest.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from services.ingest import parse_sales_from_excel
+
+
+def test_parse_sales_from_excel_uses_correct_engine(monkeypatch, tmp_path):
+    """Ensure the proper pandas engine is used for each Excel extension."""
+    used_engines = []
+
+    def fake_read_excel(path, engine=None):  # pragma: no cover - trivial stub
+        used_engines.append(engine)
+        return pd.DataFrame()
+
+    monkeypatch.setattr(pd, "read_excel", fake_read_excel)
+
+    # Test old .xls files
+    xls_file = tmp_path / "sample.xls"
+    xls_file.write_bytes(b"")
+    parse_sales_from_excel(xls_file)
+
+    # Test modern .xlsx files
+    xlsx_file = tmp_path / "sample.xlsx"
+    xlsx_file.write_bytes(b"")
+    parse_sales_from_excel(xlsx_file)
+
+    assert used_engines == ["xlrd", "openpyxl"]


### PR DESCRIPTION
## Summary
- ensure Excel uploads use the appropriate pandas engine
- add missing xlrd dependency
- test Excel engine selection in upload parsing

## Testing
- `ruff check backend/services/ingest.py backend/tests/test_ingest.py`
- `DATABASE_URL=sqlite:// pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68bb1ca704ec83219f4dae520dff2142