### PR TITLE
fix(frontend): handle KPI fetch errors

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -6,6 +6,7 @@ import Upload from "../components/Upload"; // ← ruta corregida
 
 export default function Dashboard() {
   const [kpis, setKpis] = useState(null);
+  const [error, setError] = useState("");
 
   useEffect(() => {
     const fetchKpis = async () => {
@@ -20,11 +21,14 @@ export default function Dashboard() {
         });
       } catch (err) {
         console.error("❌ Error cargando KPIs:", err);
+        setError("No se pudieron cargar los KPIs");
       }
     };
     fetchKpis();
   }, []);
 
+  if (error)
+    return <p className="p-4 text-red-600">{error}</p>;
   if (!kpis) return <p className="p-4">Cargando KPIs...</p>;
 
   const data = [


### PR DESCRIPTION
## Summary
- show a clear error when KPI data fails to load

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb1cd3667083219a0991fb9882823d