### PR TITLE
fix: configure CORS via settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
-DB_URL=postgresql+psycopg2://app:app@db:5432/marketing
+DATABASE_URL=postgresql+psycopg2://app:app@db:5432/marketing
+# Allow requests from the local frontend (comma separated for multiple origins)
+BACKEND_CORS_ORIGINS=http://localhost:5173

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,15 +1,23 @@
 # backend/core/config.py
+from typing import List
+
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
     # ⚡ Cargamos siempre desde variables de entorno o archivo .env
     DATABASE_URL: str  # Obligatorio → definido en .env
-    BACKEND_CORS_ORIGINS: str = "http://localhost:5173"  # Default seguro
+    BACKEND_CORS_ORIGINS: str = "http://localhost:5173"  # Comma-separated URLs
     APP_NAME: str = "Marketing Dashboard"  # No sensible, puede tener default
     DEBUG: bool = True  # Para desactivar logs en producción
 
-    class Config:
+    def cors_origins_list(self) -> List[str]:
+        """Return CORS origins as a list."""
+        return [o.strip() for o in self.BACKEND_CORS_ORIGINS.split(",") if o.strip()]
+
+class Config:
         env_file = ".env"   # Permite override desde .env
         case_sensitive = True
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from core.config import settings
 from api import upload, kpis
 
 app = FastAPI(
@@ -14,7 +15,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # en prod restringe
+    allow_origins=settings.cors_origins_list(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- derive allowed CORS origins from BACKEND_CORS_ORIGINS env setting
- document BACKEND_CORS_ORIGINS and DATABASE_URL in `.env.example`

## Testing
- `DATABASE_URL=sqlite:// pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb4d8945dc8321ab63d3f72d2b78e5