### PR TITLE
fix: add discount column to sales ingestion

### DIFF
--- a/backend/migrations/versions/8c66c0e9d7b1_add_discount_to_sales.py
+++ b/backend/migrations/versions/8c66c0e9d7b1_add_discount_to_sales.py
@@ -1,0 +1,29 @@
+"""add discount column to sales
+
+Revision ID: 8c66c0e9d7b1
+Revises: b0e877608ad6
+Create Date: 2025-09-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "8c66c0e9d7b1"
+down_revision = "b0e877608ad6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sales",
+        sa.Column("discount", sa.Float(), nullable=False, server_default=sa.text("0")),
+    )
+    # remove server default now that existing rows are populated
+    op.alter_column("sales", "discount", server_default=None, existing_type=sa.Float())
+
+
+def downgrade() -> None:
+    op.drop_column("sales", "discount")

--- a/backend/services/ingest.py
+++ b/backend/services/ingest.py
@@ -169,6 +169,7 @@ def _bulk_insert_sales(df: pd.DataFrame, db: Session, batch_id: str):
                 product=r.get("product"),  # compuesto
                 amount=float(r.get("amount", 0) or 0),
                 margin=float(r.get("margin_eur", 0) or 0),  # margen en €
+                discount=float(r.get("discount_pct", 0) or 0),
                 quantity=int(r.get("quantity", 0) or 0),
                 batch_id=batch_id,
             )


### PR DESCRIPTION
## Summary
- include discount when inserting sales records
- add migration to persist discount column in sales table
- refine migration to drop default safely and keep backend accessible

## Testing
- `python3 -m black backend/migrations/versions/8c66c0e9d7b1_add_discount_to_sales.py backend/services/ingest.py`
- `python3 -m ruff check backend/migrations/versions/8c66c0e9d7b1_add_discount_to_sales.py backend/services/ingest.py`
- `pytest` *(DATABASE_URL missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4d5606b8832191f5fca32727bcbf