### PR TITLE
fix upload backend default DB and frontend path

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -8,7 +8,11 @@ class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
     # ⚡ Cargamos siempre desde variables de entorno o archivo .env
-    DATABASE_URL: str  # Obligatorio → definido en .env
+    #
+    # During development and in the tests we fallback to a local SQLite
+    # database when ``DATABASE_URL`` is not provided. Production deployments
+    # **must** supply their own value via environment variables.
+    DATABASE_URL: str = "sqlite:///./test.db"
     BACKEND_CORS_ORIGINS: str = "http://localhost:5173"  # Comma-separated URLs
     APP_NAME: str = "Marketing Dashboard"  # No sensible, puede tener default
     DEBUG: bool = True  # Para desactivar logs en producción

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -14,7 +14,7 @@ export default function Upload() {
 
     try {
       setStatus("Subiendo...");
-      const res = await fetch(`http://localhost:8000/upload?mode=${mode}`, {
+      const res = await fetch(`http://localhost:8000/upload/?mode=${mode}`, {
         method: "POST",
         body: formData,
       });


### PR DESCRIPTION
## Summary
- fix backend config to default to local SQLite when DATABASE_URL missing
- correct frontend upload endpoint to include trailing slash and avoid redirect

## Testing
- `pytest`
- `ruff check backend/core/config.py`
- `npx prettier --check frontend/src/pages/Upload.jsx`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb59177e508321b095a6a22c0093c5