### PR TITLE
fix upload backend defaults and frontend path

### DIFF
--- a/backend/api/upload.py
+++ b/backend/api/upload.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Literal
 import uuid
 
-from db.session import get_db
+from db.session import Base, get_db
 from db.models import Sale, UploadHistory
 from services.ingest import (
     parse_sales_from_excel,
@@ -59,6 +59,9 @@ async def upload_file(
             pass
 
     # --- Transacción atómica (empieza aquí) ---
+    # Garantizamos que las tablas existen (por ejemplo en SQLite sin migraciones)
+    Base.metadata.create_all(bind=db.get_bind())
+
     batch_id = str(uuid.uuid4())
     try:
         with db.begin():

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -8,7 +8,11 @@ class Settings(BaseSettings):
     """Application configuration loaded from environment variables."""
 
     # ⚡ Cargamos siempre desde variables de entorno o archivo .env
-    DATABASE_URL: str  # Obligatorio → definido en .env
+    #
+    # During development and in the tests we fallback to a local SQLite
+    # database when ``DATABASE_URL`` is not provided. Production deployments
+    # **must** supply their own value via environment variables.
+    DATABASE_URL: str = "sqlite:///./test.db"
     BACKEND_CORS_ORIGINS: str = "http://localhost:5173"  # Comma-separated URLs
     APP_NAME: str = "Marketing Dashboard"  # No sensible, puede tener default
     DEBUG: bool = True  # Para desactivar logs en producción

--- a/frontend/src/components/Upload.jsx
+++ b/frontend/src/components/Upload.jsx
@@ -1,7 +1,7 @@
 // frontend/src/components/Upload.jsx
 import React, { useState } from "react";
 
-export default function Upload() {
+export default function Upload({ onRefresh }) {
   const [file, setFile] = useState(null);
   const [status, setStatus] = useState({ type: "", text: "" });
   const [history, setHistory] = useState([]);
@@ -25,7 +25,7 @@ export default function Upload() {
         type: "success",
         text: `${data.message} (batch_id: ${data.batch_id})`,
       });
-      fetchHistory();
+      refreshAll();
     } catch (err) {
       console.error(err);
       setStatus({ type: "error", text: "No se pudo subir el archivo" });
@@ -42,12 +42,14 @@ export default function Upload() {
 
   const handleUndo = async (batchId) => {
     try {
-      await fetch(`http://localhost:8000/upload/${batchId}`, { method: "DELETE" });
+      await fetch(`http://localhost:8000/upload/${batchId}`, {
+        method: "DELETE",
+      });
       setStatus({
         type: "success",
         text: `Batch ${batchId} eliminado correctamente`,
       });
-      fetchHistory();
+      refreshAll();
     } catch (err) {
       console.error(err);
       setStatus({
@@ -57,6 +59,11 @@ export default function Upload() {
     }
 
     setTimeout(() => setStatus({ type: "", text: "" }), 3000);
+  };
+
+  const refreshAll = () => {
+    fetchHistory();
+    onRefresh?.();
   };
 
   return (
@@ -72,13 +79,17 @@ export default function Upload() {
         </button>
       </div>
       {status.text && (
-        <p className={status.type === "success" ? "text-green-600" : "text-red-600"}>
+        <p
+          className={
+            status.type === "success" ? "text-green-600" : "text-red-600"
+          }
+        >
           {status.text}
         </p>
       )}
 
       <h3 className="text-lg font-semibold mt-6 mb-2">Historial de uploads</h3>
-      <button onClick={fetchHistory} className="btn-secondary mb-2">
+      <button onClick={refreshAll} className="btn-secondary mb-2">
         Refrescar
       </button>
       <table className="table">

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,34 +1,42 @@
 // frontend/src/pages/Dashboard.jsx
 import { useEffect, useState } from "react";
 import client from "../api/client";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
 import Upload from "../components/Upload"; // ← ruta corregida
 
 export default function Dashboard() {
   const [kpis, setKpis] = useState(null);
   const [error, setError] = useState("");
 
+  const fetchKpis = async () => {
+    try {
+      const res = await client.get("/kpis/basic");
+      setKpis({
+        ventas_totales: res.data.turnover ?? 0,
+        num_pedidos: res.data.orders ?? 0,
+        ticket_medio: res.data.ticket_average ?? 0,
+        margen: res.data.margin ?? 0,
+        descuento: res.data.discount ?? 0,
+      });
+    } catch (err) {
+      console.error("❌ Error cargando KPIs:", err);
+      setError("No se pudieron cargar los KPIs");
+    }
+  };
+
   useEffect(() => {
-    const fetchKpis = async () => {
-      try {
-        const res = await client.get("/kpis/basic");
-        setKpis({
-          ventas_totales: res.data.turnover ?? 0,
-          num_pedidos: res.data.orders ?? 0,
-          ticket_medio: res.data.ticket_average ?? 0,
-          margen: res.data.margin ?? 0,
-          descuento: res.data.discount ?? 0,
-        });
-      } catch (err) {
-        console.error("❌ Error cargando KPIs:", err);
-        setError("No se pudieron cargar los KPIs");
-      }
-    };
     fetchKpis();
   }, []);
 
-  if (error)
-    return <p className="p-4 text-red-600">{error}</p>;
+  if (error) return <p className="p-4 text-red-600">{error}</p>;
   if (!kpis) return <p className="p-4">Cargando KPIs...</p>;
 
   const data = [
@@ -96,7 +104,7 @@ export default function Dashboard() {
       <section>
         <h2 className="text-2xl font-bold mb-4">Carga de datos</h2>
         <div className="card">
-          <Upload />
+          <Upload onRefresh={fetchKpis} />
         </div>
       </section>
     </div>

--- a/frontend/src/pages/Upload.jsx
+++ b/frontend/src/pages/Upload.jsx
@@ -14,7 +14,7 @@ export default function Upload() {
 
     try {
       setStatus("Subiendo...");
-      const res = await fetch(`http://localhost:8000/upload?mode=${mode}`, {
+      const res = await fetch(`http://localhost:8000/upload/?mode=${mode}`, {
         method: "POST",
         body: formData,
       });


### PR DESCRIPTION
## Summary
- fix backend config to default to local SQLite when DATABASE_URL missing
- ensure tables are created before replace-mode uploads
- correct frontend upload endpoint to include trailing slash and avoid redirect
- refresh both upload history and KPI data when clicking "Refrescar"

## Testing
- `pytest`
- `npx prettier --check frontend/src/components/Upload.jsx frontend/src/pages/Dashboard.jsx`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb59177e508321b095a6a22c0093c5