### PR TITLE
fix(frontend): apply Spanish number format to KPI displays

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,8 +1,17 @@
 // frontend/src/pages/Dashboard.jsx
 import { useEffect, useState } from "react";
 import client from "../api/client";
-import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
 import Upload from "../components/Upload"; // ← ruta corregida
+import { formatNumber } from "../utils/format";
 
 export default function Dashboard() {
   const [kpis, setKpis] = useState(null);
@@ -27,8 +36,7 @@ export default function Dashboard() {
     fetchKpis();
   }, []);
 
-  if (error)
-    return <p className="p-4 text-red-600">{error}</p>;
+  if (error) return <p className="p-4 text-red-600">{error}</p>;
   if (!kpis) return <p className="p-4">Cargando KPIs...</p>;
 
   const data = [
@@ -47,35 +55,31 @@ export default function Dashboard() {
             <p className="text-gray-500">Ventas Totales</p>
 
             <h3 className="text-2xl font-bold text-indigo-600">
-              €
-              {kpis.ventas_totales.toLocaleString(undefined, {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              })}
+              €{formatNumber(kpis.ventas_totales)}
             </h3>
           </div>
           <div className="card text-center">
             <p className="text-gray-500">Nº Pedidos</p>
             <h3 className="text-2xl font-bold text-primary">
-              {kpis.num_pedidos}
+              {formatNumber(kpis.num_pedidos, 0)}
             </h3>
           </div>
           <div className="card text-center">
             <p className="text-gray-500">Ticket Medio</p>
             <h3 className="text-2xl font-bold text-primary">
-              € {kpis.ticket_medio.toFixed(2)}
+              € {formatNumber(kpis.ticket_medio)}
             </h3>
           </div>
           <div className="bg-white shadow rounded-xl p-4 text-center">
             <p className="text-gray-500">Margen</p>
             <h3 className="text-2xl font-bold text-indigo-600">
-              € {kpis.margen.toFixed(2)}
+              € {formatNumber(kpis.margen)}
             </h3>
           </div>
           <div className="bg-white shadow rounded-xl p-4 text-center">
             <p className="text-gray-500">Descuento</p>
             <h3 className="text-2xl font-bold text-indigo-600">
-              € {kpis.descuento.toFixed(2)}
+              € {formatNumber(kpis.descuento)}
             </h3>
           </div>
         </div>
@@ -84,8 +88,8 @@ export default function Dashboard() {
         <ResponsiveContainer width="100%" height={300}>
           <BarChart data={data}>
             <XAxis dataKey="name" />
-            <YAxis />
-            <Tooltip />
+            <YAxis tickFormatter={(value) => formatNumber(value)} />
+            <Tooltip formatter={(value) => value.toLocaleString("es-ES")} />
             <Legend />
             <Bar dataKey="value" fill="#6366F1" />
           </BarChart>

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -1,0 +1,10 @@
+// frontend/src/utils/format.js
+// Utility functions for consistent number formatting in Spanish locale.
+// Ensures thousands are separated with dots and decimals with commas.
+// The `decimals` parameter controls the number of decimal places displayed.
+export function formatNumber(value, decimals = 2) {
+  return value.toLocaleString("es-ES", {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}


### PR DESCRIPTION
## Summary
- format numbers in Spanish locale with a reusable `formatNumber` helper
- display KPIs and chart ticks using dots for thousands and commas for decimals

## Testing
- `npx prettier -w src/pages/Dashboard.jsx src/utils/format.js`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb5fe65498832180062730988ed9d2