### PR TITLE
fix: correct margin KPI calculation

### DIFF
--- a/backend/analytics/kpis.py
+++ b/backend/analytics/kpis.py
@@ -15,7 +15,7 @@ def get_basic_kpis(db: Session) -> Dict[str, float]:
     """Compute core KPI values combining local sales and external sources."""
     sales = db.query(Sale).all()
     turnover_local = sum(s.amount for s in sales)
-    margin = sum(s.amount * s.margin for s in sales)
+    margin = sum(s.margin for s in sales)
     discount = sum(s.amount * s.discount for s in sales)
     orders_local = len(sales)
 

--- a/backend/db/seeds.py
+++ b/backend/db/seeds.py
@@ -17,7 +17,8 @@ def seed_sales(db: Session, n=100):
         customer = random.choice(customers)
         date = datetime.today() - timedelta(days=random.randint(0, 180))
         amount = round(random.uniform(50, 500), 2)
-        margin = round(random.uniform(0.1, 0.4), 2)  # porcentaje
+        margin_pct = round(random.uniform(0.1, 0.4), 2)
+        margin = round(amount * margin_pct, 2)  # margen en €
         discount = round(random.uniform(0, 0.2), 2)  # porcentaje
         quantity = random.randint(1, 5)
 

--- a/backend/tests/test_kpis.py
+++ b/backend/tests/test_kpis.py
@@ -27,7 +27,7 @@ def test_basic_kpis(monkeypatch):
                 product="A",
                 customer="X",
                 amount=100,
-                margin=0.3,
+                margin=30,  # margen en €
                 discount=0.1,
                 quantity=1,
                 batch_id="b1",
@@ -36,7 +36,7 @@ def test_basic_kpis(monkeypatch):
                 product="B",
                 customer="Y",
                 amount=200,
-                margin=0.2,
+                margin=40,  # margen en €
                 discount=0.05,
                 quantity=2,
                 batch_id="b2",
@@ -52,7 +52,7 @@ def test_basic_kpis(monkeypatch):
     assert data["turnover"] == 300
     assert data["orders"] == 2
     assert data["ticket_average"] == 150
-    assert round(data["margin"], 2) == 100 * 0.3 + 200 * 0.2
+    assert round(data["margin"], 2) == 30 + 40
     assert round(data["discount"], 2) == 100 * 0.1 + 200 * 0.05
 
 


### PR DESCRIPTION
## Summary
- compute margin directly from stored euro amounts
- align seed data with new margin representation
- update KPI test to verify euro-based margins

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb650597a48321a6ddbbea94d42d5c