### PR TITLE
feat: add fallback KPI data

### DIFF
--- a/frontend/src/components/MarketingKpis.jsx
+++ b/frontend/src/components/MarketingKpis.jsx
@@ -16,6 +16,14 @@ export default function MarketingKpis() {
   const [error, setError] = useState("");
 
   const fetchMetrics = async () => {
+    const fallback = {
+      impressions: 10_000,
+      clicks: 500,
+      conversions: 75,
+      spend: 1_200,
+      revenue: 4_000,
+    };
+
     try {
       const res = await client.get("/kpis/marketing");
       const raw = res.data;
@@ -31,7 +39,17 @@ export default function MarketingKpis() {
       });
     } catch (err) {
       console.error("❌ Error cargando KPIs de marketing:", err);
-      setError("No se pudieron cargar los KPIs de marketing");
+      setError("Mostrando datos de ejemplo");
+      setMetrics({
+        ctr: calculateCTR(fallback.impressions, fallback.clicks),
+        cpc: calculateCPC(fallback.spend, fallback.clicks),
+        cpa: calculateCPA(fallback.spend, fallback.conversions),
+        conversion_rate: calculateConversionRate(
+          fallback.clicks,
+          fallback.conversions
+        ),
+        roas: calculateROAS(fallback.revenue, fallback.spend),
+      });
     }
   };
 
@@ -39,12 +57,12 @@ export default function MarketingKpis() {
     fetchMetrics();
   }, []);
 
-  if (error) return <p className="p-4 text-red-600">{error}</p>;
   if (!metrics) return <p className="p-4">Cargando KPIs de marketing...</p>;
 
   return (
     <section className="mt-10">
       <h2 className="text-2xl font-bold mb-6">KPIs de Marketing</h2>
+      {error && <p className="mb-4 text-yellow-600">{error}</p>}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="card text-center">
           <p className="text-gray-500">CTR</p>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -19,6 +19,14 @@ export default function Dashboard() {
   const [error, setError] = useState("");
 
   const fetchKpis = async () => {
+    const fallback = {
+      ventas_totales: 5_518,
+      num_pedidos: 244,
+      ticket_medio: 22.62,
+      margen: 1_050,
+      descuento: 180,
+    };
+
     try {
       const res = await client.get("/kpis/basic");
       setKpis({
@@ -30,7 +38,8 @@ export default function Dashboard() {
       });
     } catch (err) {
       console.error("❌ Error cargando KPIs:", err);
-      setError("No se pudieron cargar los KPIs");
+      setError("Mostrando datos de ejemplo");
+      setKpis(fallback);
     }
   };
 
@@ -38,7 +47,6 @@ export default function Dashboard() {
     fetchKpis();
   }, []);
 
-  if (error) return <p className="p-4 text-red-600">{error}</p>;
   if (!kpis) return <p className="p-4">Cargando KPIs...</p>;
 
   const data = [
@@ -49,7 +57,8 @@ export default function Dashboard() {
   return (
     <div className="p-6 space-y-10">
       <section>
-        <h2 className="text-2xl font-bold mb-6">KPIs Básicos</h2>
+        <h2 className="text-2xl font-bold mb-2">KPIs Básicos</h2>
+        {error && <p className="mb-4 text-yellow-600">{error}</p>}
 
         {/* Tarjetas */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">


### PR DESCRIPTION
## Summary
- show example basic KPIs if `/kpis/basic` fails
- display sample marketing KPI metrics when backend data is unavailable

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68be0286d9488321a3c42a915d88f863