### PR TITLE
feat: add fallback KPI data

### DIFF
--- a/frontend/src/components/MarketingKpis.jsx
+++ b/frontend/src/components/MarketingKpis.jsx
@@ -15,6 +15,18 @@ export default function MarketingKpis() {
   const [metrics, setMetrics] = useState(null);
   const [error, setError] = useState("");
 
+  const sampleMetrics = () => {
+    const impressions = 10_000 + Math.floor(Math.random() * 20_000);
+    const clicks = Math.floor(impressions * (0.02 + Math.random() * 0.08));
+    const conversions = Math.max(
+      1,
+      Math.floor(clicks * (0.05 + Math.random() * 0.2))
+    );
+    const spend = 500 + Math.random() * 4_500;
+    const revenue = spend * (1 + Math.random() * 4);
+    return { impressions, clicks, conversions, spend, revenue };
+  };
+
   const fetchMetrics = async () => {
     try {
       const res = await client.get("/kpis/marketing");
@@ -31,7 +43,18 @@ export default function MarketingKpis() {
       });
     } catch (err) {
       console.error("❌ Error cargando KPIs de marketing:", err);
-      setError("No se pudieron cargar los KPIs de marketing");
+      setError("Mostrando datos de ejemplo");
+      const fallback = sampleMetrics();
+      setMetrics({
+        ctr: calculateCTR(fallback.impressions, fallback.clicks),
+        cpc: calculateCPC(fallback.spend, fallback.clicks),
+        cpa: calculateCPA(fallback.spend, fallback.conversions),
+        conversion_rate: calculateConversionRate(
+          fallback.clicks,
+          fallback.conversions
+        ),
+        roas: calculateROAS(fallback.revenue, fallback.spend),
+      });
     }
   };
 
@@ -39,12 +62,12 @@ export default function MarketingKpis() {
     fetchMetrics();
   }, []);
 
-  if (error) return <p className="p-4 text-red-600">{error}</p>;
   if (!metrics) return <p className="p-4">Cargando KPIs de marketing...</p>;
 
   return (
     <section className="mt-10">
       <h2 className="text-2xl font-bold mb-6">KPIs de Marketing</h2>
+      {error && <p className="mb-4 text-yellow-600">{error}</p>}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="card text-center">
           <p className="text-gray-500">CTR</p>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -18,6 +18,15 @@ export default function Dashboard() {
   const [kpis, setKpis] = useState(null);
   const [error, setError] = useState("");
 
+  const sampleBasicKpis = () => {
+    const ventas_totales = 500_000 + Math.random() * 5_000_000;
+    const num_pedidos = Math.floor(50 + Math.random() * 500);
+    const ticket_medio = ventas_totales / num_pedidos;
+    const margen = ventas_totales * (0.1 + Math.random() * 0.2);
+    const descuento = ventas_totales * (0.05 + Math.random() * 0.15);
+    return { ventas_totales, num_pedidos, ticket_medio, margen, descuento };
+  };
+
   const fetchKpis = async () => {
     try {
       const res = await client.get("/kpis/basic");
@@ -30,7 +39,8 @@ export default function Dashboard() {
       });
     } catch (err) {
       console.error("❌ Error cargando KPIs:", err);
-      setError("No se pudieron cargar los KPIs");
+      setError("Mostrando datos de ejemplo");
+      setKpis(sampleBasicKpis());
     }
   };
 
@@ -38,7 +48,6 @@ export default function Dashboard() {
     fetchKpis();
   }, []);
 
-  if (error) return <p className="p-4 text-red-600">{error}</p>;
   if (!kpis) return <p className="p-4">Cargando KPIs...</p>;
 
   const data = [
@@ -49,7 +58,8 @@ export default function Dashboard() {
   return (
     <div className="p-6 space-y-10">
       <section>
-        <h2 className="text-2xl font-bold mb-6">KPIs Básicos</h2>
+        <h2 className="text-2xl font-bold mb-2">KPIs Básicos</h2>
+        {error && <p className="mb-4 text-yellow-600">{error}</p>}
 
         {/* Tarjetas */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">


### PR DESCRIPTION
## Summary
- show example basic KPIs if `/kpis/basic` fails
- display sample marketing KPI metrics when backend data is unavailable
- randomize fallback KPI values so example metrics vary on each load

## Testing
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be0286d9488321a3c42a915d88f863